### PR TITLE
Make cancel edit revert state rather than saving

### DIFF
--- a/src/components/EmployeeTable.vue
+++ b/src/components/EmployeeTable.vue
@@ -37,11 +37,11 @@
             <button @click="editEmployee(employee)">Save</button>
             <button
               class="muted-button"
-              @click="editing = null"
+              @click="cancelEdit(employee)"
             >Cancel</button>
           </td>
           <td v-else>
-            <button @click="editMode(employee.id)">Edit</button>
+            <button @click="editMode(employee)">Edit</button>
             <button @click="$emit('delete:employee', employee.id)">Delete</button>
           </td>
 
@@ -63,8 +63,14 @@ export default {
     }
   },
   methods: {
-    editMode(id) {
-      this.editing = id
+    editMode(employee) {
+      this.cachedEmployee = Object.assign({}, employee)
+      this.editing = employee.id
+    },
+
+    cancelEdit(employee) {
+      Object.assign(employee, this.cachedEmployee)
+      this.editing = null;
     },
 
     editEmployee(employee) {


### PR DESCRIPTION
Pressing `edit` copies the object's current state into a new object, and restores this if `cancel` is pressed.
Fixes #1 
